### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ Libraries that the project is using:
 
 This project licensed under the `MIT` license.
 
+
+### Dependencies 
+This mod requires:
+- `Fabric API` https://www.curseforge.com/minecraft/mc-mods/fabric-api/files

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ This project licensed under the `MIT` license.
 
 ### Dependencies 
 This mod requires:
-- `Fabric API` https://www.curseforge.com/minecraft/mc-mods/fabric-api/files
+- `Fabric API` [CurseForge](https://www.curseforge.com/minecraft/mc-mods/fabric-api), [Modrinth](https://modrinth.com/mod/fabric-api)


### PR DESCRIPTION
List Fabric API as a dependency.

Spent a few minutes wondering why my server was crashing on startup with this error. Hopefully making this dependency clear will help others.
[13:46:36] [main/FATAL]: A critical error occurred
net.fabricmc.loader.discovery.ModResolutionException: Could not find required mod: easyauth requires {fabric @ [*]}