### PR TITLE
Implement floodgate players able to bypass username restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 12) Reconnect to DB with `auth reload`
 13) Fix `hideUnauthenticatedPLayersFromPlayerList`, thanks to @Wereii
 14) Update Simplified Chinese Localization, thanks to @GodGun968
+15) Add `floodgateBypassUsernameRegex` option that allow players that join via Floodgate even if their username isn't validated by the Regex matcher, thanks to @Biel675 
 
 ### 2.2.2, Minecraft 1.17, 1.17.1, 1.18[.1], 1.18.2
 

--- a/src/main/java/xyz/nikitacartes/easyauth/event/AuthEventHandler.java
+++ b/src/main/java/xyz/nikitacartes/easyauth/event/AuthEventHandler.java
@@ -12,6 +12,7 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.math.BlockPos;
 import xyz.nikitacartes.easyauth.storage.PlayerCache;
+import xyz.nikitacartes.easyauth.utils.FloodgateApiHelper;
 import xyz.nikitacartes.easyauth.utils.PlayerAuth;
 
 import java.util.regex.Matcher;
@@ -54,7 +55,7 @@ public class AuthEventHandler {
                             config.lang.playerAlreadyOnline, onlinePlayer.getName().getContent()
                     )
             );
-        } else if (!matcher.matches()) {
+        } else if (!(matcher.matches() || (config.experimental.floodgateLoaded && config.experimental.floodgateBypassUsernameRegex && FloodgateApiHelper.isFloodgatePlayer(profile.getId())))) {
             return Text.of(
                     String.format(
                             config.lang.disallowedUsername, config.main.usernameRegex

--- a/src/main/java/xyz/nikitacartes/easyauth/storage/AuthConfig.java
+++ b/src/main/java/xyz/nikitacartes/easyauth/storage/AuthConfig.java
@@ -401,5 +401,7 @@ public class AuthConfig {
         public boolean fakePlayerApiLoaded = false;
         public boolean floodgateLoaded = false;
         public boolean ccRestitchedLoaded = false;
+
+        public boolean floodgateBypassUsernameRegex = false;
     }
 }

--- a/src/main/java/xyz/nikitacartes/easyauth/utils/FloodgateApiHelper.java
+++ b/src/main/java/xyz/nikitacartes/easyauth/utils/FloodgateApiHelper.java
@@ -4,6 +4,8 @@ import dev.cafeteria.fakeplayerapi.server.FakeServerPlayer;
 import net.minecraft.entity.player.PlayerEntity;
 import org.geysermc.floodgate.api.FloodgateApi;
 
+import java.util.UUID;
+
 public class FloodgateApiHelper{
     /**
      * Checks if player is a floodgate one.
@@ -13,7 +15,18 @@ public class FloodgateApiHelper{
      */
 
     public static boolean isFloodgatePlayer(PlayerEntity player) {
+        return isFloodgatePlayer(player.getUuid());
+    }
+
+    /**
+     * Checks if player is a floodgate one.
+     *
+     * @param uuid player's uuid to check
+     * @return true if it's fake, otherwise false
+     */
+
+    public static boolean isFloodgatePlayer(UUID uuid) {
         FloodgateApi floodgateApi = FloodgateApi.getInstance();
-        return floodgateApi.isFloodgatePlayer(player.getUuid());
+        return floodgateApi.isFloodgatePlayer(uuid);
     }
 }


### PR DESCRIPTION
Creates an option "floodgateBypassUsernameRegex" in the configuration file that if set true will allow players that join via Floodgate even if their username isn't validated by the Regex matcher.

Also, in the FloodgateApiHelper, I created a method that receives the player's UUID instead of the PlayerEntity's instance, since the latter is null as far as I've tested.