### PR TITLE
Added requireRegistrationForPremium

### DIFF
--- a/src/main/java/xyz/nikitacartes/easyauth/config/MainConfigV1.java
+++ b/src/main/java/xyz/nikitacartes/easyauth/config/MainConfigV1.java
@@ -15,6 +15,7 @@ import static xyz.nikitacartes.easyauth.utils.EasyLogger.LogError;
 @ConfigSerializable
 public class MainConfigV1 extends ConfigTemplate {
     public boolean premiumAutoLogin = true;
+    public boolean requireRegistrationForPremium = false;
     public boolean offlineByDefault = false;
     public boolean floodgateAutoLogin = true;
     public long maxLoginTries = 3;
@@ -53,6 +54,7 @@ public class MainConfigV1 extends ConfigTemplate {
     protected String handleTemplate() throws IOException {
         Map<String, String> configValues = new HashMap<>();
         configValues.put("premiumAutologin", wrapIfNecessary(premiumAutoLogin));
+        configValues.put("requireRegistrationForPremium", wrapIfNecessary(requireRegistrationForPremium));
         configValues.put("offlineByDefault", wrapIfNecessary(offlineByDefault));
         configValues.put("floodgateAutologin", wrapIfNecessary(floodgateAutoLogin));
         configValues.put("maxLoginTries", wrapIfNecessary(maxLoginTries));

--- a/src/main/java/xyz/nikitacartes/easyauth/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/xyz/nikitacartes/easyauth/mixin/ServerPlayerEntityMixin.java
@@ -174,7 +174,8 @@ public abstract class ServerPlayerEntityMixin implements PlayerAuth {
         easyAuth$setUsingMojangAccount();
         canSkipAuth = (this.player.getClass() != ServerPlayerEntity.class) ||
                 (config.floodgateAutoLogin && technicalConfig.floodgateLoaded && FloodgateApiHelper.isFloodgatePlayer(this.player)) ||
-                (easyAuth$isUsingMojangAccount() && config.premiumAutoLogin);
+                (easyAuth$isUsingMojangAccount() && config.premiumAutoLogin) &&
+                (!config.requireRegistrationForPremium || !this.playerEntryV1.password.isEmpty());
     }
 
     /**

--- a/src/main/resources/data/easyauth/config/main.conf
+++ b/src/main/resources/data/easyauth/config/main.conf
@@ -8,6 +8,9 @@
 # (cracked players will still be able to enter, but they'll need to log in)
 premium-auto-login: ${premiumAutologin}
 
+#Whether to force premium players to register when using premium-auto-login
+require-registration-for-premium: ${requireRegistrationForPremium}
+
 # Consider all players as offline players until they set online status by themselves with /account online command.
 # Also this status can be set with /auth markAsOnline/markAsOffline <player> command by admin.
 # Enabling this option will prevent "invalid session" errors


### PR DESCRIPTION
See: https://github.com/NikitaCartes/EasyAuth/issues/201

Added config option for requireRegistrationForPremium in MainConfigV1 and check in easyAuth$setSkipAuth()
It just uses password.isEmpty() to check if the user is registered

Maybe it would be better to only add it to ExtendedConfig