### PR TITLE
Add zh-cn translation

### DIFF
--- a/src/main/resources/data/easyauth/lang/zh_cn.json
+++ b/src/main/resources/data/easyauth/lang/zh_cn.json
@@ -32,5 +32,14 @@
   "text.easyauth.offlineUuid": "玩家%s的离线UUID是（点击以复制）\n%s",
   "text.easyauth.registeredPlayers": "已注册玩家列表：",
   "text.easyauth.validSession": "§a您有一个有效的会话。无需登录。",
-  "text.easyauth.onlinePlayerLogin": "§a您正在使用在线帐户。无需登录。"
+  "text.easyauth.onlinePlayerLogin": "§a您正在使用正版账户，无需登录。",
+  "text.easyauth.differentUsernameCase": "§6您输入的用户名大小写不正确，请使用正确的大小写。",
+  "text.easyauth.wrongGlobalPassword": "§4全局密码错误！",
+  "text.easyauth.registerRequiredWithGlobalPassword": "§6使用 /register §c全局密码§e §c密码§e §c密码§e 来注册该账户。",
+  "text.easyauth.markAsOffline": "§a玩家 %s 已被标记为离线账户。",
+  "text.easyauth.markAsOnline": "§a玩家 %s 已被标记为正版账户。",
+  "text.easyauth.selfMarkAsOnline": "§a你已将自己标记为正版账户玩家。",
+  "text.easyauth.selfMarkAsOnlineWarning": "§6您即将标记自己为正版账户玩家。\n§6除非您拥有一个正版账户，否则将无法登录。\n§6所有与离线UUID关联的数据（例如村民的折扣、宠物）都将丢失。\n§a如要继续，请输入 /account online §c密码§e true。",
+  "text.easyauth.accountNotFound": "§c未找到正版账户。",
+  "text.easyauth.accountCheckFailed": "§cMojang服务器不可用。请稍后再试。"
 }


### PR DESCRIPTION
Add zh-cn translation of:
- text.easyauth.differentUsernameCase
- text.easyauth.wrongGlobalPassword
- text.easyauth.registerRequiredWithGlobalPassword
- text.easyauth.markAsOffline
- text.easyauth.markAsOnline
- text.easyauth.selfMarkAsOnline
- text.easyauth.selfMarkAsOnlineWarning
- text.easyauth.accountNotFound
- text.easyauth.accountCheckFailed

Additional note: To accommodate the usage habits of Simplified Chinese players, "online account" is translated as "正版账户" (genuine account).