### PR TITLE
Support higher mongodb servers

### DIFF
--- a/src/main/java/xyz/nikitacartes/easyauth/storage/database/MongoDB.java
+++ b/src/main/java/xyz/nikitacartes/easyauth/storage/database/MongoDB.java
@@ -2,10 +2,13 @@ package xyz.nikitacartes.easyauth.storage.database;
 
 import com.mongodb.MongoClientException;
 import com.mongodb.MongoCommandException;
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
 import com.mongodb.client.*;
 import com.mongodb.client.model.InsertOneModel;
 import net.minecraft.util.Uuids;
 import org.bson.Document;
+import org.bson.UuidRepresentation;
 import xyz.nikitacartes.easyauth.config.StorageConfigV1;
 import xyz.nikitacartes.easyauth.storage.PlayerEntryV1;
 
@@ -29,7 +32,12 @@ public class MongoDB implements DbApi {
     public void connect() throws DBApiException {
         LogDebug("You are using Mongo DB");
         try {
-            mongoClient = MongoClients.create(config.mongodb.mongodbConnectionString);
+            ConnectionString connString = new ConnectionString(config.mongodb.mongodbConnectionString);
+            MongoClientSettings settings = MongoClientSettings.builder()
+                    .applyConnectionString(connString)
+                    .uuidRepresentation(UuidRepresentation.STANDARD)
+                    .build();
+            mongoClient = MongoClients.create(settings);
             MongoDatabase database = mongoClient.getDatabase(config.mongodb.mongodbDatabase);
             collection = database.getCollection("players");
         } catch (MongoClientException | MongoCommandException e) {
@@ -50,7 +58,7 @@ public class MongoDB implements DbApi {
     public void registerUser(PlayerEntryV1 data) {
         Document document = new Document("username", data.username)
                 .append("username_lower", data.usernameLowerCase)
-                .append("uuid", data.uuid)
+                .append("uuid", data.uuid == null ? null : data.uuid.toString())
                 .append("data", data.toJson());
         try {
             collection.insertOne(document);
@@ -105,7 +113,7 @@ public class MongoDB implements DbApi {
     public void updateUserData(PlayerEntryV1 data) {
         Document document = new Document("username", data.username)
                 .append("username_lower", data.usernameLowerCase)
-                .append("uuid", data.uuid)
+                .append("uuid", data.uuid == null ? null : data.uuid.toString())
                 .append("data", data.toJson());
         collection.replaceOne(eq("username", data.username), document);
     }


### PR DESCRIPTION
Starting from version 5 mongodb server changed something about "UUID Representation". (See [this](https://docs.spring.io/spring-data/mongodb/reference/migration-guide/migration-guide-4.x-to-5.x.html)). For our code we have to set explicitly `UuidRepresentation` when creating a mongo client class if I am correct.

Also I don't know which version but mongodb server started to store UUIDs as UUID type not a string if sended as a UUID type. So for better compatibility I converted UUIDs to strings when sending user data to mongodb.

I was only able to build and test this on `fabric-1.21.9`. I couldn't build it on `stonecutter` branch. (I don't know maybe its simple but I don't know java and `./gradlew build` didn't work on `stonecutter` branch but worked on `fabric-1.21.9`. (my java version is 21). But I couldn't send PR from `fabric-1.21.9`. I couldn't set git correctly I guess so I am sending to `stonecutter` from my `stonecutter`. I think the solution is simple but my PR may not enough to solve this. If its not please add compatibility to higher mongodb servers. I tried my best.