### PR TITLE
added missing strings to es_* languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This mod supports multiple languages.
 | Czech <br/>(cs_cz)                                                      |       13        |                        @DavidCZ2051, @Thewest123                        |
 | German <br/>(de_de)                                                     |       16        |                                 @X00LA                                  |
 | English <br/>(en_gb, en_us)                                             |        0        |                        @samolego, @NikitaCartes                         |
-| Spanish <br/>(es_ar, es_cl, es_ec, <br/>es_es, es_mx, es_uy,<br/>es_ve) |       16        |                      @Zailer43, @DanielTrejoBorjas                      |
+| Spanish <br/>(es_ar, es_cl, es_ec, <br/>es_es, es_mx, es_uy,<br/>es_ve) |        0        |             @Zailer43, @DanielTrejoBorjas, @danielospina-b              |
 | French <br/>(fr_fr)                                                     |       11        |                          @Uxzylon, @Sky-NiniKo                          |
 | Hungarian <br/>(hu_hu)                                                  |       16        |                             @Bendimester23                              |
 | Italian <br/>(it_it)                                                    |       13        |                               @Rizzo1812                                |

--- a/src/main/resources/data/easyauth/lang/es_ar.json
+++ b/src/main/resources/data/easyauth/lang/es_ar.json
@@ -27,5 +27,21 @@
   "text.easyauth.playerAlreadyOnline": "§c¡El jugador %s ya se encuentra conectado!",
   "text.easyauth.worldSpawnSet": "§aSpawn para iniciar sesión se estableció correctamente.",
   "text.easyauth.corruptedPlayerData": "§cSus datos probablemente estén dañados. Póngase en contacto con el administrador.",
-  "text.easyauth.userNotRegistered": "§c¡Este jugador no está registrado!"
+  "text.easyauth.userNotRegistered": "§c¡Este jugador no está registrado!",
+  "text.easyauth.cannotLogout": "§c¡No puedes cerrar sesión!",
+  "text.easyauth.offlineUuid": "UUID offline para el jugador %s (click para copiar):\n%s",
+  "text.easyauth.registeredPlayers": "Lista de jugadores registrados:",
+  "text.easyauth.validSession": "§aTienes una sesión válida. No es necesario autenticarte.",
+  "text.easyauth.onlinePlayerLogin": "§aEstás usando una cuenta en línea. No necesitas iniciar sesión.",
+  "text.easyauth.differentUsernameCase": "§6Estás usando una mayúscula/minúscula diferente en tu nombre de usuario. Por favor usa la correcta.",
+  "text.easyauth.wrongGlobalPassword": "§4¡Contraseña global incorrecta!",
+  "text.easyauth.registerRequiredWithGlobalPassword": "§6Escribe /register \u003ccontraseña global\u003e \u003ccontraseña\u003e \u003ccontraseña\u003e para reclamar esta cuenta.",
+  "text.easyauth.markAsOffline": "§aEl jugador %s se ha marcado como offline.",
+  "text.easyauth.markAsOnline": "§aEl jugador %s se ha marcado como online.",
+  "text.easyauth.selfMarkAsOnline": "§aTe has marcado como jugador online.",
+  "text.easyauth.selfMarkAsOnlineWarning": "§6Estás a punto de marcarte como jugador online.\n§6No podrás autenticarte a menos que tengas una cuenta online.\n§6Todos los datos vinculados al UUID offline (como descuentos de aldeanos, mascotas) se perderán.\n§aPara proceder, escribe /account online \u003ccontraseña\u003e true.",
+  "text.easyauth.accountNotFound": "§cCuenta online no encontrada.",
+  "text.easyauth.accountCheckFailed": "§cEl servidor de Mojang no está disponible. Por favor, inténtalo de nuevo más tarde.",
+  "text.easyauth.unknownError": "§4Ha ocurrido un error desconocido.",
+  "text.easyauth.databaseError": "§4Error en base de datos, mira la consola para más detalles."
 }

--- a/src/main/resources/data/easyauth/lang/es_cl.json
+++ b/src/main/resources/data/easyauth/lang/es_cl.json
@@ -27,5 +27,21 @@
   "text.easyauth.playerAlreadyOnline": "§c¡El jugador %s ya se encuentra conectado!",
   "text.easyauth.worldSpawnSet": "§aSpawn para iniciar sesión se estableció correctamente.",
   "text.easyauth.corruptedPlayerData": "§cSus datos probablemente estén dañados. Póngase en contacto con el administrador.",
-  "text.easyauth.userNotRegistered": "§c¡Este jugador no está registrado!"
+  "text.easyauth.userNotRegistered": "§c¡Este jugador no está registrado!",
+  "text.easyauth.cannotLogout": "§c¡No puedes cerrar sesión!",
+  "text.easyauth.offlineUuid": "UUID offline para el jugador %s (click para copiar):\n%s",
+  "text.easyauth.registeredPlayers": "Lista de jugadores registrados:",
+  "text.easyauth.validSession": "§aTienes una sesión válida. No es necesario autenticarte.",
+  "text.easyauth.onlinePlayerLogin": "§aEstás usando una cuenta en línea. No necesitas iniciar sesión.",
+  "text.easyauth.differentUsernameCase": "§6Estás usando una mayúscula/minúscula diferente en tu nombre de usuario. Por favor usa la correcta.",
+  "text.easyauth.wrongGlobalPassword": "§4¡Contraseña global incorrecta!",
+  "text.easyauth.registerRequiredWithGlobalPassword": "§6Escribe /register \u003ccontraseña global\u003e \u003ccontraseña\u003e \u003ccontraseña\u003e para reclamar esta cuenta.",
+  "text.easyauth.markAsOffline": "§aEl jugador %s se ha marcado como offline.",
+  "text.easyauth.markAsOnline": "§aEl jugador %s se ha marcado como online.",
+  "text.easyauth.selfMarkAsOnline": "§aTe has marcado como jugador online.",
+  "text.easyauth.selfMarkAsOnlineWarning": "§6Estás a punto de marcarte como jugador online.\n§6No podrás autenticarte a menos que tengas una cuenta online.\n§6Todos los datos vinculados al UUID offline (como descuentos de aldeanos, mascotas) se perderán.\n§aPara proceder, escribe /account online \u003ccontraseña\u003e true.",
+  "text.easyauth.accountNotFound": "§cCuenta online no encontrada.",
+  "text.easyauth.accountCheckFailed": "§cEl servidor de Mojang no está disponible. Por favor, inténtalo de nuevo más tarde.",
+  "text.easyauth.unknownError": "§4Ha ocurrido un error desconocido.",
+  "text.easyauth.databaseError": "§4Error en base de datos, mira la consola para más detalles."
 }

--- a/src/main/resources/data/easyauth/lang/es_ec.json
+++ b/src/main/resources/data/easyauth/lang/es_ec.json
@@ -27,5 +27,21 @@
   "text.easyauth.playerAlreadyOnline": "§c¡El jugador %s ya se encuentra conectado!",
   "text.easyauth.worldSpawnSet": "§aSpawn para iniciar sesión se estableció correctamente.",
   "text.easyauth.corruptedPlayerData": "§cSus datos probablemente estén dañados. Póngase en contacto con el administrador.",
-  "text.easyauth.userNotRegistered": "§c¡Este jugador no está registrado!"
+  "text.easyauth.userNotRegistered": "§c¡Este jugador no está registrado!",
+  "text.easyauth.cannotLogout": "§c¡No puedes cerrar sesión!",
+  "text.easyauth.offlineUuid": "UUID offline para el jugador %s (click para copiar):\n%s",
+  "text.easyauth.registeredPlayers": "Lista de jugadores registrados:",
+  "text.easyauth.validSession": "§aTienes una sesión válida. No es necesario autenticarte.",
+  "text.easyauth.onlinePlayerLogin": "§aEstás usando una cuenta en línea. No necesitas iniciar sesión.",
+  "text.easyauth.differentUsernameCase": "§6Estás usando una mayúscula/minúscula diferente en tu nombre de usuario. Por favor usa la correcta.",
+  "text.easyauth.wrongGlobalPassword": "§4¡Contraseña global incorrecta!",
+  "text.easyauth.registerRequiredWithGlobalPassword": "§6Escribe /register \u003ccontraseña global\u003e \u003ccontraseña\u003e \u003ccontraseña\u003e para reclamar esta cuenta.",
+  "text.easyauth.markAsOffline": "§aEl jugador %s se ha marcado como offline.",
+  "text.easyauth.markAsOnline": "§aEl jugador %s se ha marcado como online.",
+  "text.easyauth.selfMarkAsOnline": "§aTe has marcado como jugador online.",
+  "text.easyauth.selfMarkAsOnlineWarning": "§6Estás a punto de marcarte como jugador online.\n§6No podrás autenticarte a menos que tengas una cuenta online.\n§6Todos los datos vinculados al UUID offline (como descuentos de aldeanos, mascotas) se perderán.\n§aPara proceder, escribe /account online \u003ccontraseña\u003e true.",
+  "text.easyauth.accountNotFound": "§cCuenta online no encontrada.",
+  "text.easyauth.accountCheckFailed": "§cEl servidor de Mojang no está disponible. Por favor, inténtalo de nuevo más tarde.",
+  "text.easyauth.unknownError": "§4Ha ocurrido un error desconocido.",
+  "text.easyauth.databaseError": "§4Error en base de datos, mira la consola para más detalles."
 }

--- a/src/main/resources/data/easyauth/lang/es_es.json
+++ b/src/main/resources/data/easyauth/lang/es_es.json
@@ -27,5 +27,21 @@
   "text.easyauth.playerAlreadyOnline": "§c¡El jugador %s ya se encuentra conectado!",
   "text.easyauth.worldSpawnSet": "§aSpawn para iniciar sesión se estableció correctamente.",
   "text.easyauth.corruptedPlayerData": "§cSus datos probablemente estén dañados. Póngase en contacto con el administrador.",
-  "text.easyauth.userNotRegistered": "§c¡Este jugador no está registrado!"
+  "text.easyauth.userNotRegistered": "§c¡Este jugador no está registrado!",
+  "text.easyauth.cannotLogout": "§c¡No puedes cerrar sesión!",
+  "text.easyauth.offlineUuid": "UUID offline para el jugador %s (click para copiar):\n%s",
+  "text.easyauth.registeredPlayers": "Lista de jugadores registrados:",
+  "text.easyauth.validSession": "§aTienes una sesión válida. No es necesario autenticarte.",
+  "text.easyauth.onlinePlayerLogin": "§aEstás usando una cuenta en línea. No necesitas iniciar sesión.",
+  "text.easyauth.differentUsernameCase": "§6Estás usando una mayúscula/minúscula diferente en tu nombre de usuario. Por favor usa la correcta.",
+  "text.easyauth.wrongGlobalPassword": "§4¡Contraseña global incorrecta!",
+  "text.easyauth.registerRequiredWithGlobalPassword": "§6Escribe /register \u003ccontraseña global\u003e \u003ccontraseña\u003e \u003ccontraseña\u003e para reclamar esta cuenta.",
+  "text.easyauth.markAsOffline": "§aEl jugador %s se ha marcado como offline.",
+  "text.easyauth.markAsOnline": "§aEl jugador %s se ha marcado como online.",
+  "text.easyauth.selfMarkAsOnline": "§aTe has marcado como jugador online.",
+  "text.easyauth.selfMarkAsOnlineWarning": "§6Estás a punto de marcarte como jugador online.\n§6No podrás autenticarte a menos que tengas una cuenta online.\n§6Todos los datos vinculados al UUID offline (como descuentos de aldeanos, mascotas) se perderán.\n§aPara proceder, escribe /account online \u003ccontraseña\u003e true.",
+  "text.easyauth.accountNotFound": "§cCuenta online no encontrada.",
+  "text.easyauth.accountCheckFailed": "§cEl servidor de Mojang no está disponible. Por favor, inténtalo de nuevo más tarde.",
+  "text.easyauth.unknownError": "§4Ha ocurrido un error desconocido.",
+  "text.easyauth.databaseError": "§4Error en base de datos, mira la consola para más detalles."
 }

--- a/src/main/resources/data/easyauth/lang/es_mx.json
+++ b/src/main/resources/data/easyauth/lang/es_mx.json
@@ -27,5 +27,21 @@
   "text.easyauth.playerAlreadyOnline": "§c¡El jugador %s ya se encuentra conectado!",
   "text.easyauth.worldSpawnSet": "§aSpawn para iniciar sesión se estableció correctamente.",
   "text.easyauth.corruptedPlayerData": "§cSus datos probablemente estén dañados. Póngase en contacto con el administrador.",
-  "text.easyauth.userNotRegistered": "§c¡Este jugador no está registrado!"
+  "text.easyauth.userNotRegistered": "§c¡Este jugador no está registrado!",
+  "text.easyauth.cannotLogout": "§c¡No puedes cerrar sesión!",
+  "text.easyauth.offlineUuid": "UUID offline para el jugador %s (click para copiar):\n%s",
+  "text.easyauth.registeredPlayers": "Lista de jugadores registrados:",
+  "text.easyauth.validSession": "§aTienes una sesión válida. No es necesario autenticarte.",
+  "text.easyauth.onlinePlayerLogin": "§aEstás usando una cuenta en línea. No necesitas iniciar sesión.",
+  "text.easyauth.differentUsernameCase": "§6Estás usando una mayúscula/minúscula diferente en tu nombre de usuario. Por favor usa la correcta.",
+  "text.easyauth.wrongGlobalPassword": "§4¡Contraseña global incorrecta!",
+  "text.easyauth.registerRequiredWithGlobalPassword": "§6Escribe /register \u003ccontraseña global\u003e \u003ccontraseña\u003e \u003ccontraseña\u003e para reclamar esta cuenta.",
+  "text.easyauth.markAsOffline": "§aEl jugador %s se ha marcado como offline.",
+  "text.easyauth.markAsOnline": "§aEl jugador %s se ha marcado como online.",
+  "text.easyauth.selfMarkAsOnline": "§aTe has marcado como jugador online.",
+  "text.easyauth.selfMarkAsOnlineWarning": "§6Estás a punto de marcarte como jugador online.\n§6No podrás autenticarte a menos que tengas una cuenta online.\n§6Todos los datos vinculados al UUID offline (como descuentos de aldeanos, mascotas) se perderán.\n§aPara proceder, escribe /account online \u003ccontraseña\u003e true.",
+  "text.easyauth.accountNotFound": "§cCuenta online no encontrada.",
+  "text.easyauth.accountCheckFailed": "§cEl servidor de Mojang no está disponible. Por favor, inténtalo de nuevo más tarde.",
+  "text.easyauth.unknownError": "§4Ha ocurrido un error desconocido.",
+  "text.easyauth.databaseError": "§4Error en base de datos, mira la consola para más detalles."
 }

--- a/src/main/resources/data/easyauth/lang/es_uy.json
+++ b/src/main/resources/data/easyauth/lang/es_uy.json
@@ -27,5 +27,21 @@
   "text.easyauth.playerAlreadyOnline": "§c¡El jugador %s ya se encuentra conectado!",
   "text.easyauth.worldSpawnSet": "§aSpawn para iniciar sesión se estableció correctamente.",
   "text.easyauth.corruptedPlayerData": "§cSus datos probablemente estén dañados. Póngase en contacto con el administrador.",
-  "text.easyauth.userNotRegistered": "§c¡Este jugador no está registrado!"
+  "text.easyauth.userNotRegistered": "§c¡Este jugador no está registrado!",
+  "text.easyauth.cannotLogout": "§c¡No puedes cerrar sesión!",
+  "text.easyauth.offlineUuid": "UUID offline para el jugador %s (click para copiar):\n%s",
+  "text.easyauth.registeredPlayers": "Lista de jugadores registrados:",
+  "text.easyauth.validSession": "§aTienes una sesión válida. No es necesario autenticarte.",
+  "text.easyauth.onlinePlayerLogin": "§aEstás usando una cuenta en línea. No necesitas iniciar sesión.",
+  "text.easyauth.differentUsernameCase": "§6Estás usando una mayúscula/minúscula diferente en tu nombre de usuario. Por favor usa la correcta.",
+  "text.easyauth.wrongGlobalPassword": "§4¡Contraseña global incorrecta!",
+  "text.easyauth.registerRequiredWithGlobalPassword": "§6Escribe /register \u003ccontraseña global\u003e \u003ccontraseña\u003e \u003ccontraseña\u003e para reclamar esta cuenta.",
+  "text.easyauth.markAsOffline": "§aEl jugador %s se ha marcado como offline.",
+  "text.easyauth.markAsOnline": "§aEl jugador %s se ha marcado como online.",
+  "text.easyauth.selfMarkAsOnline": "§aTe has marcado como jugador online.",
+  "text.easyauth.selfMarkAsOnlineWarning": "§6Estás a punto de marcarte como jugador online.\n§6No podrás autenticarte a menos que tengas una cuenta online.\n§6Todos los datos vinculados al UUID offline (como descuentos de aldeanos, mascotas) se perderán.\n§aPara proceder, escribe /account online \u003ccontraseña\u003e true.",
+  "text.easyauth.accountNotFound": "§cCuenta online no encontrada.",
+  "text.easyauth.accountCheckFailed": "§cEl servidor de Mojang no está disponible. Por favor, inténtalo de nuevo más tarde.",
+  "text.easyauth.unknownError": "§4Ha ocurrido un error desconocido.",
+  "text.easyauth.databaseError": "§4Error en base de datos, mira la consola para más detalles."
 }

--- a/src/main/resources/data/easyauth/lang/es_ve.json
+++ b/src/main/resources/data/easyauth/lang/es_ve.json
@@ -27,5 +27,21 @@
   "text.easyauth.playerAlreadyOnline": "§c¡El jugador %s ya se encuentra conectado!",
   "text.easyauth.worldSpawnSet": "§aSpawn para iniciar sesión se estableció correctamente.",
   "text.easyauth.corruptedPlayerData": "§cSus datos probablemente estén dañados. Póngase en contacto con el administrador.",
-  "text.easyauth.userNotRegistered": "§c¡Este jugador no está registrado!"
+  "text.easyauth.userNotRegistered": "§c¡Este jugador no está registrado!",
+  "text.easyauth.cannotLogout": "§c¡No puedes cerrar sesión!",
+  "text.easyauth.offlineUuid": "UUID offline para el jugador %s (click para copiar):\n%s",
+  "text.easyauth.registeredPlayers": "Lista de jugadores registrados:",
+  "text.easyauth.validSession": "§aTienes una sesión válida. No es necesario autenticarte.",
+  "text.easyauth.onlinePlayerLogin": "§aEstás usando una cuenta en línea. No necesitas iniciar sesión.",
+  "text.easyauth.differentUsernameCase": "§6Estás usando una mayúscula/minúscula diferente en tu nombre de usuario. Por favor usa la correcta.",
+  "text.easyauth.wrongGlobalPassword": "§4¡Contraseña global incorrecta!",
+  "text.easyauth.registerRequiredWithGlobalPassword": "§6Escribe /register \u003ccontraseña global\u003e \u003ccontraseña\u003e \u003ccontraseña\u003e para reclamar esta cuenta.",
+  "text.easyauth.markAsOffline": "§aEl jugador %s se ha marcado como offline.",
+  "text.easyauth.markAsOnline": "§aEl jugador %s se ha marcado como online.",
+  "text.easyauth.selfMarkAsOnline": "§aTe has marcado como jugador online.",
+  "text.easyauth.selfMarkAsOnlineWarning": "§6Estás a punto de marcarte como jugador online.\n§6No podrás autenticarte a menos que tengas una cuenta online.\n§6Todos los datos vinculados al UUID offline (como descuentos de aldeanos, mascotas) se perderán.\n§aPara proceder, escribe /account online \u003ccontraseña\u003e true.",
+  "text.easyauth.accountNotFound": "§cCuenta online no encontrada.",
+  "text.easyauth.accountCheckFailed": "§cEl servidor de Mojang no está disponible. Por favor, inténtalo de nuevo más tarde.",
+  "text.easyauth.unknownError": "§4Ha ocurrido un error desconocido.",
+  "text.easyauth.databaseError": "§4Error en base de datos, mira la consola para más detalles."
 }


### PR DESCRIPTION
Added missing 16 strings to Spanish language files. The strings should be generic enough to be applicable to all spanish variations. But changes are welcome to improve localization for specific variations.