### PR TITLE
support for online mode with controlled offline players list (premiumAutoLoginAllowUnknownOffline)

### DIFF
--- a/src/main/java/xyz/nikitacartes/easyauth/config/MainConfigV1.java
+++ b/src/main/java/xyz/nikitacartes/easyauth/config/MainConfigV1.java
@@ -30,6 +30,12 @@ public class MainConfigV1 extends ConfigTemplate {
 
     @Comment("""
             
+            Whether to allow connection for offline players not present in technical.forcedOfflinePlayers list
+            and not present in player cache""")
+    public boolean premiumAutoLoginAllowUnknownOffline = false;
+
+    @Comment("""
+            
             How long to keep session (auto-logging in the player), in seconds.
             Set to -1 to disable.
             For more information, see https://github.com/NikitaCartes/EasyAuth/wiki/Sessions""")

--- a/src/main/java/xyz/nikitacartes/easyauth/mixin/ServerLoginPacketListenerImplMixin.java
+++ b/src/main/java/xyz/nikitacartes/easyauth/mixin/ServerLoginPacketListenerImplMixin.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static xyz.nikitacartes.easyauth.EasyAuth.config;
 import static xyz.nikitacartes.easyauth.integrations.MojangApi.getUuid;
 import static xyz.nikitacartes.easyauth.utils.EasyLogger.*;
 
@@ -97,20 +98,24 @@ public abstract class ServerLoginPacketListenerImplMixin {
                         playerData.update();
                         // Authentication continues in the original method
                     } else {
-                        if (onlineUuid == null) {
-                            LogDebug("Player " + username + " doesn't have a Mojang account");
-                            playerData.onlineAccount = PlayerEntryV1.OnlineAccount.FALSE;
-                            playerData.update();
-                        } else {
-                            LogInfo("Player " + username + " has a Mojang account, but UUID mismatch: expected " + onlineUuid + ", got " + packet.profileId());
-                            if (!EasyAuth.extendedConfig.checkOfflinePlayersWithOnlineUsernames) {
+                        final boolean allowOffline = config.premiumAutoLoginAllowUnknownOffline;
+                        LogDebug("Player " + username + " doesn't have a Mojang account. " + (allowOffline? "Allowing" : "NOT allowing") + " to be offline");
+                        if ( allowOffline ) {
+                            if (onlineUuid == null) {
+                                LogDebug("Player " + username + " doesn't have a Mojang account");
                                 playerData.onlineAccount = PlayerEntryV1.OnlineAccount.FALSE;
                                 playerData.update();
+                            } else {
+                                LogInfo("Player " + username + " has a Mojang account, but UUID mismatch: expected " + onlineUuid + ", got " + packet.profileId());
+                                if (!EasyAuth.extendedConfig.checkOfflinePlayersWithOnlineUsernames) {
+                                    playerData.onlineAccount = PlayerEntryV1.OnlineAccount.FALSE;
+                                    playerData.update();
+                                }
                             }
+                            state = getReadyState();
+                            this.authenticatedProfile = getGameProfile(packet.name());
+                            ci.cancel();
                         }
-                        state = getReadyState();
-                        this.authenticatedProfile = getGameProfile(packet.name());
-                        ci.cancel();
                     }
                 }
             } catch (IOException e) {


### PR DESCRIPTION
this PR adds premiumAutoLoginAllowUnknownOffline config value which enables support for hybrid (online/offline) mode server authentication as follows:
 - online players are free to join (online mode)
 - only select offline players are allowed to join (markAsOffline'ed)
